### PR TITLE
correct leap year calculation

### DIFF
--- a/myCalender2/CalenderView.swift
+++ b/myCalender2/CalenderView.swift
@@ -89,9 +89,9 @@ class CalenderView: UIView, UICollectionViewDelegate, UICollectionViewDataSource
         todaysDate = Calendar.current.component(.day, from: Date())
         firstWeekDayOfMonth=getFirstWeekDay()
         
-        //for leap years, make february month of 29 days
-        if currentMonthIndex == 2 && currentYear % 4 == 0 {
-            numOfDaysInMonth[currentMonthIndex-1] = 29
+        //set number of days for February
+        if currentMonthIndex == 2 {
+            numOfDaysInMonth[currentMonthIndex-1] = leapDays(currentYear)
         }
         //end
         
@@ -163,17 +163,20 @@ class CalenderView: UIView, UICollectionViewDelegate, UICollectionViewDataSource
         return day
     }
     
+    func leapDays(_ year: Int) -> Int {
+        if year % 4 == 0 && (year % 100 != 0 || (year % 100 == 0 && year % 400 == 0)) {
+            return 29
+        }
+        return 28
+    }
+    
     func didChangeMonth(monthIndex: Int, year: Int) {
         currentMonthIndex=monthIndex+1
         currentYear = year
         
-        //for leap year, make february month of 29 days
+        //set number of days for February
         if monthIndex == 1 {
-            if currentYear % 4 == 0 {
-                numOfDaysInMonth[monthIndex] = 29
-            } else {
-                numOfDaysInMonth[monthIndex] = 28
-            }
+            numOfDaysInMonth[monthIndex] = leapDays(currentYear)
         }
         //end
         


### PR DESCRIPTION
From [Introduction to Calendars](http://aa.usno.navy.mil/faq/docs/calendars.php):

> The Gregorian Calendar has become the internationally accepted civil calendar. The leap year rule for the Gregorian Calendar differs slightly from one for the Julian Calendar. The Gregorian leap year rule is: Every year that is exactly divisible by four is a leap year, except for years that are exactly divisible by 100, but these centurial years are leap years if they are exactly divisible by 400. For example, the years 1700, 1800, and 1900 are not leap years, but the year 2000 is. The Gregorian dates for Easter are computed from a set of ecclesiastical rules and tables.